### PR TITLE
Fix subnetwork specification to use a URL

### DIFF
--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -320,7 +320,7 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
                 .map { subNetwork ->
                     val networkId = getResourceId(subNetwork.network, networkClient.settings)
                     val network = ProjectGlobalNetworkName.parse(networkId).network
-                    subNetwork.name to listOf(nonEmpty(subNetwork.description, subNetwork.name), network)
+                    ("regions/$region/subnetworks/" + subNetwork.name) to listOf(nonEmpty(subNetwork.description, subNetwork.name), network)
                 }
                 .sortedWith(compareBy(comparator) { it -> it.second.first() })
                 .associate { it -> it.first to it.second }


### PR DESCRIPTION
This prevents the 400 Bad Request error that looks like `"Invalid value for field 'resource.networkInterfaces[0].subnetwork'`. It's probably not exactly the correct way of constructing the URL, though.

Fixes #25.