### PR TITLE
Add TeamCity metadata to that of an Instance Template

### DIFF
--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -161,7 +161,7 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
 
         val instanceTemplateBuilder = getInstanceTemplate(instance).toBuilder()
         LOG.info("GCP Instance Template: $instanceTemplateBuilder")
-        LOG.info("Instance Template properties captured from GCP: ${instanceTemplateBuilder.getProperties().toBuilder()}")
+        LOG.info("Instance Template properties captured from GCP: ${instanceTemplateBuilder.getProperties()}")
         val instanceTemplateMetadataBuilder = instanceTemplateBuilder
                 .getProperties()
                 .toBuilder()
@@ -174,7 +174,7 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
                         GoogleConstants.TAG_SOURCE to details.sourceId
                 ))?.getItemsList())
 
-        LOG.info("Creating an instance builder from merged metadata: $instanceTemplateMetadataBuilder")
+        LOG.info("Creating an instance builder from merged metadata")
         val instanceInfo = getInstanceBuilder(instance, true)
                 .setMetadata(instanceTemplateMetadataBuilder.build())
                 .build()

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -159,15 +159,27 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
         val details = instance.image.imageDetails
         val zone = details.zone
 
-        val instanceInfo = getInstanceBuilder(instance)
-                .setMetadata(getMetadata(mutableMapOf(
+        val instanceTemplateBuilder = getInstanceTemplate(instance).toBuilder()
+        LOG.info("GCP Instance Template: $instanceTemplateBuilder")
+        LOG.info("Instance Template properties captured from GCP: ${instanceTemplateBuilder.getProperties().toBuilder()}")
+        val instanceTemplateMetadataBuilder = instanceTemplateBuilder
+                .getProperties()
+                .toBuilder()
+                .getMetadata()
+                .toBuilder()
+                .addAllItems(getMetadata(mutableMapOf(
                         GoogleConstants.TAG_SERVER to myServerId,
                         GoogleConstants.TAG_DATA to userData.serialize(),
                         GoogleConstants.TAG_PROFILE to myProfileId,
                         GoogleConstants.TAG_SOURCE to details.sourceId
-                )))
+                ))?.getItemsList())
+
+        LOG.info("Creating an instance builder from merged metadata: $instanceTemplateMetadataBuilder")
+        val instanceInfo = getInstanceBuilder(instance, true)
+                .setMetadata(instanceTemplateMetadataBuilder.build())
                 .build()
 
+        LOG.info("Creating instance from Instance Template: ${instanceTemplateBuilder.getName()}")
         instanceClient.insertInstanceCallable().futureCall(InsertInstanceHttpRequest.newBuilder()
                 .setSourceInstanceTemplate(ProjectGlobalInstanceTemplateName.of(details.instanceTemplate, myProjectId).value)
                 .setZone(ProjectZoneName.of(myProjectId, zone).value)
@@ -178,6 +190,15 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
         Unit
     }
 
+    private fun getInstanceBuilder(instance: GoogleCloudInstance, fromTemplate: Boolean): Instance.Builder {
+
+        if (fromTemplate)
+            return Instance.newBuilder()
+                    .setName(instance.instanceId)
+
+        return getInstanceBuilder(instance)
+    }
+
     private fun getInstanceBuilder(instance: GoogleCloudInstance): Instance.Builder {
         return Instance.newBuilder()
                 .setName(instance.instanceId)
@@ -186,6 +207,18 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
                         .setOnHostMaintenance("TERMINATE")
                         .setPreemptible(instance.image.imageDetails.preemptible)
                         .build())
+    }
+
+    private fun getInstanceTemplate(instance: GoogleCloudInstance): InstanceTemplate {
+        LOG.info("getInstanceTemplate template name: ${instance.image.imageDetails.instanceTemplate}")
+        LOG.info("getInstanceTemplate GCP project ID: $myProjectId")
+        val instanceTemplateName = ProjectGlobalInstanceTemplateName.of(
+                instance.image.imageDetails.instanceTemplate,
+                myProjectId
+        )
+
+        LOG.info("GCP get Instance Template: $instanceTemplateName")
+        return instanceTemplateClient.getInstanceTemplate(instanceTemplateName.toString())
     }
 
     private fun getMetadata(metadata: Map<String, String?>): Metadata? {

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -159,9 +159,9 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
         val details = instance.image.imageDetails
         val zone = details.zone
 
+        LOG.info("Fetching Google Instance Template")
         val instanceTemplateBuilder = getInstanceTemplate(instance).toBuilder()
-        LOG.info("GCP Instance Template: $instanceTemplateBuilder")
-        LOG.info("Instance Template properties captured from GCP: ${instanceTemplateBuilder.getProperties()}")
+        LOG.info("Google Instance Template properties captured from GCP")
         val instanceTemplateMetadataBuilder = instanceTemplateBuilder
                 .getProperties()
                 .toBuilder()


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/TW-61898

Prior to the change the `getInstanceBuilder` was overwriting the Instance Template's `Custom metadata` with the `setMetadata` action.

This change pulls the configured Instance Template's information from GCP and adds the existing metadata to the custom TeamCity server ones before setting it for the new instance. In addition, a new method, `getInstanceBuilder`, also avoids overwriting the `Availability policies` in the newly created instance as well (values are inherited from the Instance Template).

All changes are tested in a staging environment with simulated workload.