### PR TITLE
Add support for specifying GCP Source project for images/image families

### DIFF
--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleCloudClientFactory.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleCloudClientFactory.kt
@@ -87,6 +87,7 @@ class GoogleCloudClientFactory(cloudRegistrar: CloudRegistrar,
                     it.getParameter(GoogleConstants.IMAGE_TYPE)?.let { type ->
                         GoogleCloudImageType.valueOf(type)
                     },
+                    it.getParameter(GoogleConstants.SOURCE_PROJECT),
                     it.getParameter(GoogleConstants.SOURCE_IMAGE),
                     it.getParameter(GoogleConstants.SOURCE_IMAGE_FAMILY),
                     it.getParameter(GoogleConstants.INSTANCE_TEMPLATE),

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleCloudImageDetails.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleCloudImageDetails.kt
@@ -29,6 +29,8 @@ class GoogleCloudImageDetails(
         private val sourceId: String,
         @SerializedName(GoogleConstants.IMAGE_TYPE)
         val imageType: GoogleCloudImageType?,
+        @SerializedName(GoogleConstants.SOURCE_PROJECT)
+        val sourceProject: String?,
         @SerializedName(GoogleConstants.SOURCE_IMAGE)
         val sourceImage: String?,
         @SerializedName(GoogleConstants.SOURCE_IMAGE_FAMILY)

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleConstants.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/GoogleConstants.kt
@@ -39,6 +39,9 @@ class GoogleConstants {
     val imageType: String
         get() = IMAGE_TYPE
 
+    val sourceProject: String
+        get() = SOURCE_PROJECT
+
     val sourceImage: String
         get() = SOURCE_IMAGE
 
@@ -111,6 +114,7 @@ class GoogleConstants {
         const val CREDENTIALS_KEY = "key"
         const val ACCESS_KEY = Constants.SECURE_PROPERTY_PREFIX + "accessKey"
         const val IMAGE_TYPE = "imageType"
+        const val SOURCE_PROJECT = "sourceProject"
         const val SOURCE_IMAGE = "sourceImage"
         const val SOURCE_IMAGE_FAMILY = "sourceImageFamily"
         const val INSTANCE_TEMPLATE = "instanceTemplate"

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnector.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnector.kt
@@ -37,9 +37,9 @@ interface GoogleApiConnector : CloudApiConnector<GoogleCloudImage, GoogleCloudIn
 
     suspend fun stopVm(instance: GoogleCloudInstance)
 
-    suspend fun getImages(): Map<String, String>
+    suspend fun getImages(project: String?): Map<String, String>
 
-    suspend fun getImageFamilies(): List<String>
+    suspend fun getImageFamilies(project: String?): List<String>
 
     suspend fun getTemplates(): Map<String, String>
 

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -120,10 +120,12 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
         }
 
 
+        val instanceBootImageProject = if (details.sourceProject.isNullOrBlank()) myProjectId else details.sourceProject
+
         @Suppress("IMPLICIT_CAST_TO_ANY")
         val instanceBootImage = when(details.imageType) {
-            GoogleCloudImageType.Image -> ProjectGlobalImageName.format(details.sourceImage, details.sourceProject)
-            GoogleCloudImageType.ImageFamily -> ProjectGlobalImageFamilyName.format(details.sourceImageFamily, details.sourceProject)
+            GoogleCloudImageType.Image -> ProjectGlobalImageName.format(details.sourceImage, instanceBootImageProject)
+            GoogleCloudImageType.ImageFamily -> ProjectGlobalImageFamilyName.format(details.sourceImageFamily, instanceBootImageProject)
             else -> LOG.warn("Invalid imageType: ${details.imageType}")
         }
 

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/connector/GoogleApiConnectorImpl.kt
@@ -122,8 +122,8 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
 
         @Suppress("IMPLICIT_CAST_TO_ANY")
         val instanceBootImage = when(details.imageType) {
-            GoogleCloudImageType.Image -> ProjectGlobalImageName.format(details.sourceImage, myProjectId)
-            GoogleCloudImageType.ImageFamily -> ProjectGlobalImageFamilyName.format(details.sourceImageFamily, myProjectId)
+            GoogleCloudImageType.Image -> ProjectGlobalImageName.format(details.sourceImage, details.sourceProject)
+            GoogleCloudImageType.ImageFamily -> ProjectGlobalImageFamilyName.format(details.sourceImageFamily, details.sourceProject)
             else -> LOG.warn("Invalid imageType: ${details.imageType}")
         }
 
@@ -309,10 +309,11 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
 
     override fun checkInstance(instance: GoogleCloudInstance): Array<TypedCloudErrorInfo> = emptyArray()
 
-    override suspend fun getImages() = coroutineScope {
+    override suspend fun getImages(project: String?) = coroutineScope {
+        val projectName = if (project.isNullOrBlank()) myProjectId else project
         val images = imageClient.listImagesPagedCallable()
                 .futureCall(ListImagesHttpRequest.newBuilder()
-                        .setProject(ProjectName.format(myProjectId))
+                        .setProject(ProjectName.format(projectName))
                         .build())
                 .await()
 
@@ -322,10 +323,11 @@ class GoogleApiConnectorImpl : GoogleApiConnector {
                 .associate { it.first to it.second }
     }
 
-    override suspend fun getImageFamilies() = coroutineScope {
+    override suspend fun getImageFamilies(project: String?) = coroutineScope {
+        val projectName = if (project.isNullOrBlank()) myProjectId else project
         val images = imageClient.listImagesPagedCallable()
                 .futureCall(ListImagesHttpRequest.newBuilder()
-                        .setProject(ProjectName.format(myProjectId))
+                        .setProject(ProjectName.format(projectName))
                         .build())
                 .await()
 

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/types/GoogleImageFamilyHandler.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/types/GoogleImageFamilyHandler.kt
@@ -33,7 +33,7 @@ class GoogleImageFamilyHandler(private val connector: GoogleApiConnector) : Goog
         if (details.sourceImageFamily.isNullOrEmpty()) {
             exceptions.add(CheckedCloudException("Image Family should not be empty"))
         } else {
-            if (!connector.getImageFamilies().contains(details.sourceImageFamily)) {
+            if (!connector.getImageFamilies(details.sourceProject).contains(details.sourceImageFamily)) {
                 exceptions.add(CheckedCloudException("Image Family does not exist"))
             }
         }

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/types/GoogleImageHandler.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/types/GoogleImageHandler.kt
@@ -33,7 +33,7 @@ class GoogleImageHandler(private val connector: GoogleApiConnector) : GoogleHand
         if (details.sourceImage.isNullOrEmpty()) {
             exceptions.add(CheckedCloudException("Image should not be empty"))
         } else {
-            if (!connector.getImages().containsKey(details.sourceImage)) {
+            if (!connector.getImages(details.sourceProject).containsKey(details.sourceImage)) {
                 exceptions.add(CheckedCloudException("Image does not exist"))
             }
         }

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/web/ImageFamiliesHandler.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/web/ImageFamiliesHandler.kt
@@ -25,7 +25,7 @@ import org.jdom.Element
  */
 internal class ImageFamiliesHandler : GoogleResourceHandler() {
     override suspend fun handle(connector: GoogleApiConnector, parameters: Map<String, String>) = coroutineScope {
-        val imageFamilies = connector.getImageFamilies()
+        val imageFamilies = connector.getImageFamilies(parameters.getOrDefault("sourceProject", ""))
         val imageFamiliesElement = Element("imageFamilies")
 
         for (family in imageFamilies) {

--- a/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/web/ImagesHandler.kt
+++ b/google-cloud-server/src/main/kotlin/jetbrains/buildServer/clouds/google/web/ImagesHandler.kt
@@ -25,7 +25,7 @@ import org.jdom.Element
  */
 internal class ImagesHandler : GoogleResourceHandler() {
     override suspend fun handle(connector: GoogleApiConnector, parameters: Map<String, String>) = coroutineScope {
-        val images = connector.getImages()
+        val images = connector.getImages(parameters.getOrDefault("sourceProject", ""))
         val imagesElement = Element("images")
 
         for ((id, displayName) in images) {

--- a/google-cloud-server/src/main/resources/buildServerResources/settings.jsp
+++ b/google-cloud-server/src/main/resources/buildServerResources/settings.jsp
@@ -110,6 +110,15 @@
                     <span class="error option-error" data-bind="text: errorResources"></span>
                 </td>
             </tr>
+            <tr>
+                <th><label for="${cons.sourceProject}">Source Project: </label></th>
+                <td>
+                    <input type="text" name="${cons.sourceProject}" class="longField ignoreModified"
+                           data-bind="textInput: image().sourceProject"/>
+                    <span class="smallNote">The Service Account should be granted 'compute.images.list' permissions</span>
+                    <span class="error option-error" data-bind="validationMessage: image().sourceProject"></span>
+                </td>
+            </tr>
             <tr data-bind="if: image().imageType() == 'Image'">
                 <th><label for="${cons.sourceImage}">Image: <l:star/></label></th>
                 <td>


### PR DESCRIPTION
Add support for launching agents using images from a different project.

This can be useful if images are in a different project to that which the agents are being launched in.

Set a 500ms timeout on the `Source Project` input to ensure that not refreshing images on every key press.

Closes #41

**N.B:** This builds on #42, so will need to merge that one first.
The relevant commit that adds this functionality is [`db5c8e6` (#44)](https://github.com/JetBrains/teamcity-google-agent/pull/44/commits/db5c8e6be38b45573acfd060667d6ea308f9ad9f)
