### PR TITLE
TW-78108 Remove ability to edit JSON key through the UI

### DIFF
--- a/google-cloud-server/src/main/resources/buildServerResources/settings.jsp
+++ b/google-cloud-server/src/main/resources/buildServerResources/settings.jsp
@@ -41,29 +41,11 @@
         <tr data-bind="css: {hidden: credentials().type() != '${cons.credentialsKey}' }">
             <th><label for="${cons.accessKey}">JSON private key: <l:star/></label></th>
             <td>
-                <div data-bind="visible: showAccessKey || !isValidCredentials()" style="display: none">
-                    <div>Edit JSON key:</div>
-                    <textarea name="prop:${cons.accessKey}" class="longField"
-                              rows="5" cols="49"
-                              data-bind="initializeValue: credentials().accessKey,
-                              textInput: credentials().accessKey, event: {
-                              dragover: function() { return false },
-                              dragenter: function() { dragEnterHandler(); },
-                              dragleave: function() { dragLeaveHandler(); },
-                              drop: function(data, event) { return dropHandler(event) } },
-                              css: { attentionComment: isDragOver }"><c:out
-                              value="${propertiesBean.properties[cons.accessKey]}"/></textarea>
-                    <span data-bind="css: {invisible: !validatingKey()}">
-                        <i class="icon-refresh icon-spin"></i>
-                    </span>
-                </div>
-                <a href="#" data-bind="click: function() { showAccessKey(true) }, visible: !showAccessKey()">Edit JSON key</a>
-                <span class="smallNote">Specify the JSON private key.</span>
                 <div data-bind="visible: hasFileReader">
                     <input type="file"
-                           data-bind="event: { change: function() { loadAccessKey($element.files[0]) } }"/>
+                           data-bind="event: { change: function() { loadAccessKey($element.files[0]); validatingKey(); } }"/>
                 </div>
-                <span class="error option-error" data-bind="validationMessage: credentials().accessKey"></span>
+                <span class="smallNote">Specify the JSON private key.</span>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
In my opinion, having the ability to edit such a key through the UI is not something we usually allow anyways, so I think removing it actually makes sense. The user can still upload it as a file and will get information if there's an error.

I think allowing the user to paste the text of the JSON there doesn't directly bring any value. 
But pls, I'd love to hear your thoughts on this one as this is a highly opinionated question.

<img width="950" alt="Screenshot 2025-02-21 at 19 31 25" src="https://github.com/user-attachments/assets/342ba53c-b43d-4262-9718-9db5c7cfe344" />
